### PR TITLE
feat: implement Droideka about MFE

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "application-shell-test",
   "version": "0.1.0",
   "scripts": {
-    "start:all": "npm-run-all --parallel start:shell start:mfe1",
+    "start:all": "npm-run-all --parallel start:shell start:mfe1 start:about",
     "start": "webpack serve --config webpack.config.js",
     "start:shell": "webpack serve --config webpack.config.js",
     "start:mfe1": "webpack serve --config webpack.mfe1.config.js",

--- a/src/about-module/about.scss
+++ b/src/about-module/about.scss
@@ -1,42 +1,30 @@
-body {
-  font-family: Arial, sans-serif;
-  margin: 0;
-  padding: 0;
-  background-color: #f4f4f4;
-  color: #333;
-}
+// Design tokens for the Droideka about MFE.
+// These are not imported at runtime — the component uses inline styles.
+// Kept here as a reference for a future CSS library integration.
 
-header {
-  background-color: #333;
-  color: #fff;
-  padding: 10px;
-  text-align: center;
-}
+// Color tokens
+$color-bg:        #0d0d0d;
+$color-surface:   #161616;
+$color-border:    #222222;
+$color-text:      #e8e8e8;
+$color-text-muted:#aaaaaa;
+$color-text-dim:  #555555;
 
-section {
-  max-width: 800px;
-  margin: 20px auto;
-  padding: 20px;
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
+// Typography tokens
+$font-family:     'Segoe UI', Arial, sans-serif;
+$font-size-base:  16px;
+$font-size-sm:    14px;
+$font-size-xs:    11px;
+$font-weight-bold:    700;
+$font-weight-light:   300;
+$letter-spacing-wide: 4px;
+$letter-spacing-btn:  2px;
+$line-height-body:    1.7;
 
-h1 {
-  color: #333;
-}
-
-p {
-  line-height: 1.6;
-}
-
-footer {
-  background-color: #333;
-  color: #fff;
-  text-align: center;
-  padding: 10px;
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-}
+// Spacing tokens
+$spacing-xs:  16px;
+$spacing-sm:  24px;
+$spacing-md:  40px;
+$spacing-lg:  60px;
+$spacing-xl:  80px;
 

--- a/src/about-module/component.ts
+++ b/src/about-module/component.ts
@@ -1,34 +1,130 @@
-// static imports do currently not work with shared libs,
-// hence the dynamic one inside an async IIFE below
-// import * as sharedLib from 'shared-lib';
-
 class MicroFrontend2 extends HTMLElement {
     constructor() {
         super();
         this.attachShadow({mode: 'open'});
     }
 
-    async connectedCallback() {
-        if (this.shadowRoot) {
-            this.shadowRoot.innerHTML = `
-                <link rel="stylesheet" type="text/css" href="about.scss">
-                <div>
-                    <section>
-                        <h2>About Us</h2>
-                        <p>Welcome to Airline Ticket Reservations, your go-to platform for hassle-free flight bookings. We are committed to providing you with a seamless and enjoyable travel experience. Whether you're planning a business trip or a vacation, we've got you covered.</p>
-                
-                        <p>At Airline Ticket Reservations, we pride ourselves on offering a wide range of flight options, competitive prices, and user-friendly interfaces. Our team is dedicated to ensuring that your journey begins with a smooth and efficient booking process.</p>
-                
-                        <p>Explore our website to discover the latest deals, manage your reservations, and stay informed about your upcoming flights. We value your time and strive to make your travel arrangements as convenient as possible.</p>
-                
-                        <p>Thank you for choosing Airline Ticket Reservations. We look forward to being a part of your travel adventures!</p>
-                    </section>
-                </div>
-            `;
-
-        } else {
+    connectedCallback() {
+        if (!this.shadowRoot) {
             throw new Error('shadowRoot is null');
         }
+
+        const styles = `
+            :host {
+                display: block;
+                font-family: 'Segoe UI', Arial, sans-serif;
+                background-color: #0d0d0d;
+                color: #e8e8e8;
+                min-height: 100vh;
+                box-sizing: border-box;
+            }
+
+            * {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+
+            .hero {
+                padding: 80px 40px 60px;
+                border-bottom: 1px solid #222;
+            }
+
+            .hero__eyebrow {
+                font-size: 11px;
+                letter-spacing: 4px;
+                text-transform: uppercase;
+                color: #888;
+                margin-bottom: 20px;
+            }
+
+            .hero__name {
+                font-size: clamp(48px, 8vw, 96px);
+                font-weight: 700;
+                letter-spacing: -2px;
+                line-height: 1;
+                color: #ffffff;
+                margin-bottom: 16px;
+            }
+
+            .hero__tagline {
+                font-size: clamp(18px, 3vw, 28px);
+                font-weight: 300;
+                color: #aaaaaa;
+                max-width: 560px;
+            }
+
+            .mission {
+                padding: 60px 40px;
+                border-bottom: 1px solid #222;
+                max-width: 720px;
+            }
+
+            .mission__label {
+                font-size: 11px;
+                letter-spacing: 4px;
+                text-transform: uppercase;
+                color: #555;
+                margin-bottom: 24px;
+            }
+
+            .mission__text {
+                font-size: 18px;
+                line-height: 1.7;
+                color: #cccccc;
+            }
+
+            .mission__text + .mission__text {
+                margin-top: 16px;
+            }
+
+            .cta {
+                padding: 60px 40px;
+            }
+
+            .cta__button {
+                display: inline-block;
+                padding: 14px 36px;
+                border: 1px solid #e8e8e8;
+                color: #e8e8e8;
+                background: transparent;
+                font-size: 14px;
+                letter-spacing: 2px;
+                text-transform: uppercase;
+                cursor: pointer;
+                transition: background 0.2s, color 0.2s;
+            }
+
+            .cta__button:hover {
+                background: #e8e8e8;
+                color: #0d0d0d;
+            }
+        `;
+
+        this.shadowRoot.innerHTML = `
+            <style>${styles}</style>
+            <div class="hero">
+                <p class="hero__eyebrow">Est. 2024</p>
+                <h1 class="hero__name">Droideka</h1>
+                <p class="hero__tagline">We build modern robots.</p>
+            </div>
+            <div class="mission">
+                <p class="mission__label">Our Mission</p>
+                <p class="mission__text">
+                    Droideka designs and engineers autonomous robots for the real world.
+                    From precision manufacturing arms to adaptive field units, our machines
+                    are built to operate where humans cannot — or should not.
+                </p>
+                <p class="mission__text">
+                    We believe robotics should be reliable, maintainable, and open to
+                    integration. Every Droideka unit ships with a modular architecture
+                    so your team can extend, reprogram, and deploy with confidence.
+                </p>
+            </div>
+            <div class="cta">
+                <button class="cta__button">Explore our robots</button>
+            </div>
+        `;
     }
 }
 

--- a/src/about-module/index.html
+++ b/src/about-module/index.html
@@ -1,9 +1,11 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>MicroFrontend 2</title>
-    <link rel="stylesheet" href="about.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Droideka — About</title>
 </head>
-<body>
+<body style="margin:0;background:#0d0d0d;">
 <microfrontend-two></microfrontend-two>
 </body>
 </html>

--- a/webpack.about.config.js
+++ b/webpack.about.config.js
@@ -6,7 +6,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const production = process.env.NODE_ENV === "production";
 
 const about = {
-    entry: "./src/about/main",
+    entry: "./src/about-module/main",
     output: {
         publicPath: "http://localhost:47002/",
         uniqueName: 'about',
@@ -17,7 +17,7 @@ const about = {
     mode: production ? "production" : "development",
     devtool: production ? "source-map" : "eval-source-map",
     devServer: {
-        watchFiles: ['./src/about/**/*', "main.html"],
+        watchFiles: ['./src/about-module/**/*'],
         static: './dist/about',
         port: 47002,
         headers: {
@@ -30,6 +30,23 @@ const about = {
             {
                 test: /\.css$/i,
                 use: [MiniCssExtractPlugin.loader, 'css-loader'],
+            },
+            {
+                test: /\.scss$/,
+                exclude: /node_modules/,
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    'css-loader',
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            postcssOptions: {
+                                plugins: [['postcss-preset-env', {}]],
+                            },
+                        },
+                    },
+                    'sass-loader',
+                ],
             },
             {
                 test: /\.ts$/,
@@ -48,14 +65,14 @@ const about = {
             library: {type: "var", name: "about"},
             filename: "remoteEntry.js",
             exposes: {
-                "./component": "./src/about/component"
+                "./component": "./src/about-module/component"
             },
             shared: {
                 "rxjs": {},
             }
         }),
         new HtmlWebpackPlugin({
-            template: "./src/about/index.html"
+            template: "./src/about-module/index.html"
         }),
     ]
 };


### PR DESCRIPTION
## Summary

Implements the `about` micro-frontend for Droideka. The MFE was previously a stub with broken webpack paths and placeholder airline copy. It now serves a complete, branded page at port 47002 and loads correctly via `#/about` in the shell.

## Changes

- **`src/about-module/component.ts`** — Replaced airline stub with a Droideka-branded Web Component. Sections: hero (company name + tagline), mission (two paragraphs), CTA button. Styles are an inline CSS template literal scoped to Shadow DOM, ready to be swapped out when a CSS library is added.
- **`webpack.about.config.js`** — Fixed broken entry and HTML template paths (`./src/about/` → `./src/about-module/`). Added SCSS loader chain (sass-loader → postcss-loader → css-loader → MiniCssExtractPlugin) to match the shell config.
- **`src/about-module/about.scss`** — Replaced generic global rules with SCSS design tokens (colors, typography, spacing) as a reference for future CSS library integration. Not imported at runtime.
- **`src/about-module/index.html`** — Added `<!DOCTYPE html>`, removed broken CSS link, set dark background for standalone dev server preview.
- **`package.json`** — `start:all` now includes `start:about` so all three MFEs (47000, 47001, 47002) start in parallel.

## Testing

```bash
npm run lint:shell   # passes
npm run build:about  # compiles successfully
npm run start:all    # starts shell + mfe1 + about in parallel
```

Navigate to `#/about` in the shell to verify the page renders.